### PR TITLE
Fixes and new features

### DIFF
--- a/ACAcommons.c
+++ b/ACAcommons.c
@@ -209,6 +209,16 @@ void updateRequestedTorque(void) {
 		ui16_sum_torque /= NUMBER_OF_PAS_MAGS;
 
 	}
+
+	//For cruise behaviour -> cruise is disabled on these conditions
+	if (ui8_cruiseThrottleSetting > 0) {
+		if (ui16_sum_throttle > ui8_cruiseMinThrottle + 5) {
+			ui8_cruiseThrottleSetting = 0;
+		}
+		if (ui16_sum_throttle < ui8_cruiseMinThrottle) {
+			ui8_cruiseMinThrottle = ui16_sum_throttle;
+		}
+	}
 }
 
 void checkPasInActivity(void) {

--- a/ACAcontrollerState.c
+++ b/ACAcontrollerState.c
@@ -159,6 +159,7 @@ void controllerstate_init(void) {
 	ui8_a_s_assistlevels[5] =LEVEL_5;
 	ui16_aca_flags = ACA;
 	ui16_aca_experimental_flags = ACA_EXPERIMENTAL;
+	ui16_aca_experimental_flags |= 32; //sine wave table used (useful when not able to select in app)
 	ui8_s_battery_voltage_calibration = ADC_BATTERY_VOLTAGE_K;
 	ui8_s_battery_voltage_min = BATTERY_VOLTAGE_MIN_VALUE;
 	ui8_s_battery_voltage_max = BATTERY_VOLTAGE_MAX_VALUE;

--- a/ACAcontrollerState.c
+++ b/ACAcontrollerState.c
@@ -140,6 +140,8 @@ uint8_t light_stat = 0;
 uint8_t walk_stat = 0;
 
 uint8_t ui8_moving_indication = 0;
+uint8_t ui8_cruiseThrottleSetting = 0;
+uint8_t ui8_cruiseMinThrottle = 0;
 
 void controllerstate_init(void) {
 	uint8_t di;

--- a/ACAcontrollerState.h
+++ b/ACAcontrollerState.h
@@ -138,6 +138,8 @@ extern uint8_t light_stat;
 extern uint8_t walk_stat;
 
 extern uint8_t ui8_moving_indication;
+extern uint8_t ui8_cruiseThrottleSetting;
+extern uint8_t ui8_cruiseMinThrottle;
 
 void controllerstate_init(void);
 

--- a/ACAsetPoint.c
+++ b/ACAsetPoint.c
@@ -171,10 +171,11 @@ uint16_t aca_setpoint(uint16_t ui16_time_ticks_between_pas_interrupt, uint16_t s
 
 			//Current target based on linear input on pad X4
 		} else {
-			ui8_temp = map(ui16_x4_value >> 2, ui8_throttle_min_range, ui8_throttle_max_range, 0, 100); //map regen throttle to limits
+			ui8_temp = map(ui16_x4_value >> 2, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //map regen throttle to limits
+			//ui8_temp = map(ui16_momentary_throttle, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //use throttle to vary regen when braking
 			controll_state_temp -= 2;
 		}
-		float_temp = (float) ui8_temp * (float) (ui16_regen_current_max_value) / 100.0;
+		float_temp = (float) ui8_temp * (ui16_regen_current_max_value >> 7);
 
 		//Current target gets ramped down with speed
 		if (((ui16_aca_flags & SPEED_INFLUENCES_REGEN) == SPEED_INFLUENCES_REGEN) && (ui16_virtual_erps_speed < ((ui16_speed_kph_to_erps_ratio * ((uint16_t) ui8_speedlimit_kph)) / 100))) {

--- a/ACAsetPoint.c
+++ b/ACAsetPoint.c
@@ -172,8 +172,8 @@ uint16_t aca_setpoint(uint16_t ui16_time_ticks_between_pas_interrupt, uint16_t s
 
 			//Current target based on linear input on pad X4
 		} else {
-			//ui8_temp = map(ui16_x4_value >> 2, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //map regen throttle to limits
-			ui8_temp = map(ui16_momentary_throttle, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //use throttle to vary regen when braking
+			ui8_temp = map(ui16_x4_value >> 2, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //map regen throttle to limits
+			//ui8_temp = map(ui16_momentary_throttle, ui8_throttle_min_range, ui8_throttle_max_range, 0, 128); //use throttle to vary regen when braking
 			controll_state_temp -= 2;
 		}
 		float_temp = ((ui8_temp * ui16_regen_current_max_value) >> 7);

--- a/ACAsetPoint.c
+++ b/ACAsetPoint.c
@@ -219,17 +219,18 @@ uint16_t aca_setpoint(uint16_t ui16_time_ticks_between_pas_interrupt, uint16_t s
 				ui8_temp += ui8_assist_dynamic_percent_addon;
 			}
 
-			if (ui16_time_ticks_between_pas_interrupt_smoothed > ui16_s_ramp_end && ui16_time_ticks_between_pas_interrupt_smoothed < ui16_s_ramp_start) { //ramp end usually 1500
+			if (ui16_time_ticks_between_pas_interrupt_smoothed > ui16_s_ramp_end) { //ramp end usually 1500
 				//if you are pedaling slower than defined ramp end
 				//but faster than ramp start
 				//current is proportional to cadence
+				if (ui16_time_ticks_between_pas_interrupt_smoothed < ui16_s_ramp_start) {
 					uint32_current_target = (ui8_temp * (ui16_battery_current_max_value) / 100);
 					float_temp = 1.0 - (((float)(ui16_time_ticks_between_pas_interrupt_smoothed - ui16_s_ramp_end)) / ((float)(ui16_s_ramp_start - ui16_s_ramp_end)));
 					uint32_current_target = ((uint16_t)(uint32_current_target) * (uint16_t)(float_temp * 100.0)) / 100 + ui16_current_cal_b;
 					controll_state_temp += 1;
 					ui8_moving_indication |= (16);
 					ui8_cruiseThrottleSetting = 0; //no cruise when pedalling, just like stock
-
+				}
 				//in you are pedaling faster than in ramp end defined, desired battery current level is set,
 			} else {
 				uint32_current_target = (ui8_temp * (ui16_battery_current_max_value) / 100 + ui16_current_cal_b);

--- a/ACAsetPoint.c
+++ b/ACAsetPoint.c
@@ -222,6 +222,7 @@ uint16_t aca_setpoint(uint16_t ui16_time_ticks_between_pas_interrupt, uint16_t s
 			if (ui16_time_ticks_between_pas_interrupt_smoothed > ui16_s_ramp_end) { //ramp end usually 1500
 				//if you are pedaling slower than defined ramp end
 				//but faster than ramp start
+				// if pedaling slower then ramp start, the current target stays at current cal b
 				//current is proportional to cadence
 				if (ui16_time_ticks_between_pas_interrupt_smoothed < ui16_s_ramp_start) {
 					uint32_current_target = (ui8_temp * (ui16_battery_current_max_value) / 100);

--- a/display.c
+++ b/display.c
@@ -203,7 +203,8 @@ void display_update() {
 		    		((ui8_crc ^ 7) == ui8_rx_buffer [5]) ||
 		    		((ui8_crc ^ 8) == ui8_rx_buffer [5]) ||
 		    		((ui8_crc ^ 14) == ui8_rx_buffer [5]) ||
-				((ui8_crc ^ 9) == ui8_rx_buffer [5])) // CRC LCD3
+				((ui8_crc ^ 9) == ui8_rx_buffer [5])) ||// CRC LCD3
+				((ui8_crc ^ 23) == ui8_rx_buffer[5])) // CRC of an LCD8
 		{
 			// added by DerBastler Light On/Off 
 			lcd_configuration_variables.ui8_light_On = ui8_rx_buffer [1] & 128;

--- a/display.c
+++ b/display.c
@@ -208,7 +208,7 @@ void display_update() {
 		    		((ui8_crc ^ 7) == ui8_rx_buffer [5]) ||
 		    		((ui8_crc ^ 8) == ui8_rx_buffer [5]) ||
 		    		((ui8_crc ^ 14) == ui8_rx_buffer [5]) ||
-				((ui8_crc ^ 9) == ui8_rx_buffer [5])) ||// CRC LCD3
+				((ui8_crc ^ 9) == ui8_rx_buffer [5]) ||// CRC LCD3
 				((ui8_crc ^ 23) == ui8_rx_buffer[5])) // CRC of an LCD8
 		{
 			// added by DerBastler Light On/Off 
@@ -223,7 +223,15 @@ void display_update() {
 			lcd_configuration_variables.ui8_max_speed = 10 + ((ui8_rx_buffer [2] & 248) >> 3) | (ui8_rx_buffer [4] & 32);
 			lcd_configuration_variables.ui8_wheel_size = ((ui8_rx_buffer [4] & 192) >> 6) | ((ui8_rx_buffer [2] & 7) << 2);
 
-			lcd_configuration_variables.ui8_p1 = ui8_rx_buffer[3];
+			if (lcd_configuration_variables.ui8_assist_level != (ui8_assistlevel_global && 15)) { //cruise disables when switching assist levels, just like stock
+				ui8_cruiseThrottleSetting = 0;
+			}
+			else if (ui8_rx_buffer[8] == 0x10 && lcd_configuration_variables.ui8_assist_level != 0 && ui8_cruiseThrottleSetting == 0) {
+				ui8_cruiseThrottleSetting = ui16_sum_throttle;
+				ui8_cruiseMinThrottle = ui8_cruiseThrottleSetting;
+			}
+
+			/*lcd_configuration_variables.ui8_p1 = ui8_rx_buffer[3];
 			lcd_configuration_variables.ui8_p2 = ui8_rx_buffer[4] & 0x07;
 			lcd_configuration_variables.ui8_p3 = ui8_rx_buffer[4] & 0x08;
 			lcd_configuration_variables.ui8_p4 = ui8_rx_buffer[4] & 0x10;
@@ -235,7 +243,7 @@ void display_update() {
 			lcd_configuration_variables.ui8_c5 = (ui8_rx_buffer[7] & 0x0F);
 			lcd_configuration_variables.ui8_c12 = (ui8_rx_buffer[9] & 0x0F);
 			lcd_configuration_variables.ui8_c13 = (ui8_rx_buffer[10] & 0x1C) >> 2;
-			lcd_configuration_variables.ui8_c14 = (ui8_rx_buffer[7] & 0x60) >> 5;
+			lcd_configuration_variables.ui8_c14 = (ui8_rx_buffer[7] & 0x60) >> 5;*/
 
 			digestLcdValues();
 			send_message();

--- a/display.c
+++ b/display.c
@@ -52,6 +52,7 @@ uint8_t ui8_rx_buffer_counter = 0;
 uint8_t ui8_byte_received;
 
 uint8_t ui8_UARTCounter = 0;
+uint8_t ui8_cruiseHasBeenLow;
 
 volatile struc_lcd_configuration_variables lcd_configuration_variables;
 
@@ -223,15 +224,19 @@ void display_update() {
 			lcd_configuration_variables.ui8_max_speed = 10 + ((ui8_rx_buffer [2] & 248) >> 3) | (ui8_rx_buffer [4] & 32);
 			lcd_configuration_variables.ui8_wheel_size = ((ui8_rx_buffer [4] & 192) >> 6) | ((ui8_rx_buffer [2] & 7) << 2);
 
-			if (lcd_configuration_variables.ui8_assist_level != (ui8_assistlevel_global && 15)) { //cruise disables when switching assist levels, just like stock
+			if (ui8_rx_buffer[8] == 0) {
+				ui8_cruiseHasBeenLow = 1;
+			}
+			if (lcd_configuration_variables.ui8_assist_level != (ui8_assistlevel_global & 15)) { //cruise disables when switching assist levels, just like stock
 				ui8_cruiseThrottleSetting = 0;
 			}
-			else if (ui8_rx_buffer[8] == 0x10 && lcd_configuration_variables.ui8_assist_level != 0 && ui8_cruiseThrottleSetting == 0) {
+			else if (ui8_rx_buffer[8] == 16 && lcd_configuration_variables.ui8_assist_level != 0 && ui8_cruiseThrottleSetting == 0 && ui8_cruiseHasBeenLow == 1) {
+				ui8_cruiseHasBeenLow = 0;
 				ui8_cruiseThrottleSetting = ui16_sum_throttle;
 				ui8_cruiseMinThrottle = ui8_cruiseThrottleSetting;
 			}
 
-			/*lcd_configuration_variables.ui8_p1 = ui8_rx_buffer[3];
+			lcd_configuration_variables.ui8_p1 = ui8_rx_buffer[3];
 			lcd_configuration_variables.ui8_p2 = ui8_rx_buffer[4] & 0x07;
 			lcd_configuration_variables.ui8_p3 = ui8_rx_buffer[4] & 0x08;
 			lcd_configuration_variables.ui8_p4 = ui8_rx_buffer[4] & 0x10;
@@ -243,7 +248,7 @@ void display_update() {
 			lcd_configuration_variables.ui8_c5 = (ui8_rx_buffer[7] & 0x0F);
 			lcd_configuration_variables.ui8_c12 = (ui8_rx_buffer[9] & 0x0F);
 			lcd_configuration_variables.ui8_c13 = (ui8_rx_buffer[10] & 0x1C) >> 2;
-			lcd_configuration_variables.ui8_c14 = (ui8_rx_buffer[7] & 0x60) >> 5;*/
+			lcd_configuration_variables.ui8_c14 = (ui8_rx_buffer[7] & 0x60) >> 5;
 
 			digestLcdValues();
 			send_message();

--- a/display.c
+++ b/display.c
@@ -136,7 +136,12 @@ void send_message() {
 	// each unit of B8 = 0.25A
 
 
-	ui8_tx_buffer [8] = (uint8_t) ((((ui16_BatteryCurrent - ui16_current_cal_b + 1) << 2)*10) / ui8_current_cal_a);
+	if (ui16_BatteryCurrent <= ui16_current_cal_b + 2) { //avoid full power displayed at regen and avoid small watts being displayed when the bike is just standing still
+		ui8_tx_buffer[8] = 0;
+	}
+	else {
+		ui8_tx_buffer[8] = (uint8_t)((((ui16_BatteryCurrent - ui16_current_cal_b - 1) << 2) * 10) / ui8_current_cal_a);
+	}
 	// B9: motor temperature
 	ui8_tx_buffer [9] = i8_motor_temperature - 15; //according to documentation at endless sphere
 	// B10 and B11: 0

--- a/documentation/LCD3_to_S12SN-1.txt
+++ b/documentation/LCD3_to_S12SN-1.txt
@@ -60,7 +60,7 @@ B7: parameter C5 and C7
 b7b6b5b4 b3b2b1b0
 . . . .  c3c2c1c0      param C5 (mask 0x0F)
 . c1c0.  . . . .       param C14 (mask 0x60)
-B8: parameter C4
+B8: parameter C4       on LCD8H B8==0x10,16 when cruise control going to be enabled
 b7b6b5b4 b3b2b1b0
 c2c1c0.  . . . .       param C4  (mask 0xE0)
 B9: parameter C12


### PR DESCRIPTION
I thought I would test the master branch and the one thing I changed from my local branch, screwed the current target calculation up, now it works again.
I am testing the field weakening now, but I didn't want to have a bug in the master code, so that is why I am already creating a second pull request now.
I added the CRC for my LCD8.
Also added and tested cruise on LCD8.
And improved the battery current calculation for the LCD, which produced overflow before on regen.
It starts in sine wave mode now when the eeprom is reset during programming.